### PR TITLE
Include documentation and license in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGES.rst
+include LICENSE.txt
+include README.rst


### PR DESCRIPTION
It is important for the license file to be included in sdists for legal reasons.