### PR TITLE
PKG: Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(
         'Topic :: Communications',
         'Topic :: Software Development :: Libraries',
     ],
-    package_data=data_files
+    package_data=data_files,
+    include_package_data=True
 )


### PR DESCRIPTION
This commit ensures that `LICENSE.txt` is included in the distribution created via `python setup.py sdist`.