### PR TITLE
PKG: Package `simpleio.dll` with `pyparallel`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/win32/simpleio.dll

--- a/parallel/parallelwin32.py
+++ b/parallel/parallelwin32.py
@@ -54,7 +54,8 @@ LPT1_base = 0x0378
 LPT2_base = 0x0278
 
 # need to patch PATH so that the DLL can be found and loaded
-os.environ['PATH'] = os.environ['PATH'] + ';' + os.path.abspath(os.path.dirname(__file__))
+dll_path = os.path.abspath(os.path.dirname(__file__)) + '\\win32'
+os.environ['PATH'] = os.environ['PATH'] + ';' + dll_path
 # fake module, names of the functions are the same as in the old _pyparallel
 # python extension in earlier versions of this modules
 _pyparallel = ctypes.windll.simpleio

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,10 @@ if sys.version < '2.2.3':
     DistributionMetadata.classifiers = None
     DistributionMetadata.download_url = None
 
-if os.name == 'nt':
-    # set dependencies for windows version
-    data_files = {'parallel': ['simpleio.dll']}
-else:
-    # no dependencies
-    data_files = {}
-
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
     name='pyparallel',
@@ -35,7 +29,9 @@ setup(
     author='Chris Liechti',
     author_email='cliechti@gmx.net',
     url='https://github.com/pyserial/pyparallel',
-    packages=['parallel'],
+    packages=['parallel', 'parallel.win32'],
+    package_dir={'parallel': 'parallel',
+                 'parallel.win32': 'src/win32'},
     setup_requires=[
         "flake8"
     ],
@@ -54,5 +50,5 @@ setup(
         'Topic :: Communications',
         'Topic :: Software Development :: Libraries',
     ],
-    package_data=data_files
+    include_package_data=True
 )


### PR DESCRIPTION
This commit alters `setup.py` such that `simpleio.dll` will get packaged with `pyparallel` both when building an `sdist` or a `bdist_wheel`.

For this, we create a "fake subpackage" `parallel.win32`, which will contain the `simpleio.dll` file (specified in `MANIFEST.in`) from `src/win32` (specified in `setup.py`: `package_dir` kwarg). That is,
`simpleio.dll` will be installed as `parallel/win32/simpleio.dll` in the `site-packages` folder.

I have updated `parallelwin32.py` to assume this path accordingly.

I have removed the system-dependent inclusion of `simpleio.dll` in `setup.py`, meaning it will now be included in all distributions on all platforms. This is beneficial because it allows to build the
package on a non-Windows platform, but Windows users will still be able to use it with the included `simpleio.dll`. (Also, I didn't know how to preserve the old behavior ;))